### PR TITLE
Fix typos across blog posts and about page

### DIFF
--- a/Content/about/index.md
+++ b/Content/about/index.md
@@ -12,10 +12,10 @@ Nice to have you here! 👐
 
 And now I should say something about me ... I guess 🤓 ... I'm interested in podcasts, music, cooking and of course programming.
 
-Most of my projects can be found an [GitHub](https://github.com/JulianKahnert).
+Most of my projects can be found on [GitHub](https://github.com/JulianKahnert).
 Currently [Swift](https://swift.org) is my first choice! 🤓
 
-In the last years I also started using Kubernetes, Helm and some the other nice little helpers in the DevOps corner of GitHub.
+In the last years I also started using Kubernetes, Helm and some of the other nice little helpers in the DevOps corner of GitHub.
 
 In my spare time I develop [PDF Archiver](http://ios.pdf-archiver.io).
 An iOS & macOS App that helps you to scan 🔎 and organize 🗃 your documents.

--- a/Content/posts/2018-03-03--pdf-archiver.md
+++ b/Content/posts/2018-03-03--pdf-archiver.md
@@ -1,7 +1,7 @@
 ---
 date: 2018-03-03 00:00
 title: PDF Archiver
-description: In this blogpost we will discuss the nameing convention and background of PDF Archiver. A tool for tagging files and archiving tasks.
+description: In this blogpost we will discuss the naming convention and background of PDF Archiver. A tool for tagging files and archiving tasks.
 tags: pdfarchiver
 ---
 

--- a/Content/posts/2019-05-16--pdf-archiver-ios.md
+++ b/Content/posts/2019-05-16--pdf-archiver-ios.md
@@ -83,7 +83,7 @@ So all you have to do is enter a description and click save (or `⌘ s` 😊).
 The automatic date and tag suggestions were the basis for the next step of the [PDF Archiver Project](http://github.com/pdf-Archiver/).
 The iPhone has a smaller display (compared to Macs), but we always carry it with us.
 I'm very happy to announce that there will be an iOS version of PDF Archiver soon.
-With it the slogan **"Scan it. Day it. Find it."** now finally is fully reached!
+With it the slogan **"Scan it. Tag it. Find it."** now finally is fully reached!
 
 ### Scan it.
 New documents can be easily scanned.

--- a/Content/posts/2021-02-24--swift-log.md
+++ b/Content/posts/2021-02-24--swift-log.md
@@ -15,7 +15,7 @@ Let's have a deeper look at it now. 🤓
 
 The `swift-log` module contains 2 parts, which we will have a look at in the next sections.
 Let's first have a look at how to produce log entries.
-Afterwards we dive into handling these logs and how there two parts are connected.
+Afterwards we dive into handling these logs and how these two parts are connected.
 
 ### Produce Logs
 
@@ -113,7 +113,7 @@ The framework introduces a [`LogHandler`](https://github.com/apple/swift-log/blo
 There are already some `LogHandler` implementations mentioned in the [`swift-log` README](https://github.com/apple/swift-log) which is a great starting point for your research.
 
 In [PDF Archiver](https://pdf-archiver.io) I use [Sentry.io](https://sentry.io/) as a crash reporter.
-Since it really helps if you get a little context of the situation the user was in, while a crash has happend, I created the [`SentryBreadcrumbLogger`](https://github.com/PDF-Archiver/PDF-Archiver/blob/bfc8cac12a3417f45302c45127020056b38568ea/ArchiveCore/Sources/ArchiveSharedConstants/Logging/SentryBreadcrumbLogger.swift#L11).
+Since it really helps if you get a little context of the situation the user was in, while a crash has happened, I created the [`SentryBreadcrumbLogger`](https://github.com/PDF-Archiver/PDF-Archiver/blob/bfc8cac12a3417f45302c45127020056b38568ea/ArchiveCore/Sources/ArchiveSharedConstants/Logging/SentryBreadcrumbLogger.swift#L11).
 It is an implementation of the `LogHandler` `protocol`.
 Essentially, it creates a `Breadcrumb` that contains all information that a entry log contains.
 
@@ -159,7 +159,7 @@ LoggingSystem.bootstrap { label in
 
 Ok let's recap: we know how to create a `Logger` instance and that `LoggingSystem.bootstrap()` defines a factory that returns a `LogHandler`.
 
-You might ask yourself: *Why did you writing about a logging system?* 🤓
+You might ask yourself: *Why am I writing about a logging system?* 🤓
 
 Granted, this is not fancy topic but I like to learn on examples and maybe these ones are useful for someone else too.
 But I also want to add the statement: **Your libraries should make use of `swift-log`!**

--- a/Content/posts/2021-08-09--network-debugging-on-macos.md
+++ b/Content/posts/2021-08-09--network-debugging-on-macos.md
@@ -10,7 +10,7 @@ The last time someone asked _My internet is broken, can you help me?_ I thought 
 
 In this post I want to show some tips and tricks on how to find common networking problems.
 
-When I approach a networking problem, I try to get some structure in my debugging workingflow by using the [OSI model](https://en.wikipedia.org/wiki/OSI_model).
+When I approach a networking problem, I try to get some structure in my debugging workflow by using the [OSI model](https://en.wikipedia.org/wiki/OSI_model).
 We will have a look at each layer and try to isolate the problem layer by layer.
 
 ## OSI layers
@@ -29,18 +29,18 @@ It is intended to be a short checklist and therefore does not include more in-de
 
 ### **3** Network
 
-- Is the cloudflare namesever reachable: `ping 1.1` (aka. `ping 1.0.0.1`)
+- Is the cloudflare nameserver reachable: `ping 1.1` (aka. `ping 1.0.0.1`)
 - Do I have the right `IP address`?
-  - `169.254.0.0/16` are link local addresses ([RFC5735](https://datatracker.ietf.org/doc/html/rfc5735)) that might be self assigned by your machine -> DHCP servier not reachable.
+  - `169.254.0.0/16` are link local addresses ([RFC5735](https://datatracker.ietf.org/doc/html/rfc5735)) that might be self assigned by your machine -> DHCP server not reachable.
   - IP address of guest network?
 
 ### **4-7** Transport, Session, Presentation, Application
 
 - Is the DNS resolution working properly?
   - Get DNS record `$ dig A juliankahnert.de`
-  - Ask a specific namesever: `$ dig A juliankahnert.de @1.1`
+  - Ask a specific nameserver: `$ dig A juliankahnert.de @1.1`
 - Response correct (HTTP status code etc.) `$ curl -I http://juliankahnert.de`
-- Validate the [certifcate](https://serverfault.com/a/749381):
+- Validate the [certificate](https://serverfault.com/a/749381):
   `$ curl --insecure -vvI https://juliankahnert.de/ 2>&1 | awk 'BEGIN { cert=0 } /^\* SSL connection/ { cert=1 } /^\*/ { if (cert) print }'`
 
 ## Other Use Cases
@@ -52,7 +52,7 @@ This can reveal the hoster (e.g. _Hetzner_ or _Uberspace_).
 
 ### Where can I change the DNS records?
 
-You might have more than one registrar and want to find to namesever responsible for a (sub)domain.
+You might have more than one registrar and want to find to nameserver responsible for a (sub)domain.
 
 ```
 $ dig NS juliankahnert.de
@@ -67,7 +67,7 @@ If you have changed DNS records and you can clear the cache of some nameservers:
 - [Cloudflare](https://1.1.1.1/purge-cache/)
 - [Google](https://developers.google.com/speed/public-dns/cache)
 
-You can use a [DNS Checker](https://dnschecker.org) to valide DNS changes.
+You can use a [DNS Checker](https://dnschecker.org) to validate DNS changes.
 
 Tip: Set a short DNS record TTL some time before you make changes. This will speed up the DNS propagation and your testing afterwards.
 

--- a/Content/posts/2023-05-24--pdf-archiver-sharing.md
+++ b/Content/posts/2023-05-24--pdf-archiver-sharing.md
@@ -25,13 +25,13 @@ In diesem Blogpost erfährst du, wie du diese Funktion nutzen kannst, um deine P
 
 Der Quellcode der App ist auf [GitHub einsehbar](https://github.com/PDF-Archiver/pdf-archiver), wodurch Entwickler und interessierte Nutzer den Code einsehen, Forks erstellen und zur Weiterentwicklung beitragen können.
 Dieses neue Feature, das es ermöglicht, den Archivordner zu teilen, wurde von [Robert Hahn](https://github.com/Maschina) entwickelt, der einen Pull Request eingereicht hat, um die Funktion in PDF Archiver zu integrieren.
-Ich möchte Robert für seine Beitrag danken und freue mich die *OpenSource* Aspekte des Projektes weiter mit Leben zu füllen.
+Ich möchte Robert für seinen Beitrag danken und freue mich die *OpenSource* Aspekte des Projektes weiter mit Leben zu füllen.
 
 ## Sicherheitshinweis
 
 Bevor du Änderungen an deinem Archiv vornimmst, ist es ratsam, ein Backup deiner Daten zu erstellen.
 Dadurch kannst du sicherstellen, dass deine wertvollen Dokumente geschützt sind.
-Grundsätlich sollten Backups in regelmäßigen Abständen erstellt werden, um potenziellen Datenverlust zu vermeiden.
+Grundsätzlich sollten Backups in regelmäßigen Abständen erstellt werden, um potenziellen Datenverlust zu vermeiden.
 
 ## Fazit
 


### PR DESCRIPTION
## Summary
This PR fixes multiple spelling and grammar errors found across the blog:

### About Page (`Content/about/index.md`)
- Fixed: "an GitHub" → "on GitHub"
- Fixed: "some the other" → "some of the other"

### Blog Posts
**2018-03-03--pdf-archiver.md**
- Fixed: "nameing" → "naming" (in description)

**2019-05-16--pdf-archiver-ios.md**
- Fixed: "Day it" → "Tag it" (important slogan correction!)

**2021-02-24--swift-log.md**
- Fixed: "there two parts" → "these two parts"
- Fixed: "has happend" → "has happened"
- Fixed: "Why did you writing" → "Why am I writing"

**2021-08-09--network-debugging-on-macos.md**
- Fixed: "workingflow" → "workflow"
- Fixed: "namesever" → "nameserver" (4 instances)
- Fixed: "servier" → "server"
- Fixed: "certifcate" → "certificate"
- Fixed: "valide" → "validate"

**2023-05-24--pdf-archiver-sharing.md**
- Fixed: "seine Beitrag" → "seinen Beitrag"
- Fixed: "Grundsätlich" → "Grundsätzlich"

## Changes
- 6 files changed
- 16 insertions, 16 deletions
- No functional changes, only spelling/grammar corrections